### PR TITLE
Ch537/Add event listeners to core

### DIFF
--- a/Memory.lua
+++ b/Memory.lua
@@ -35,7 +35,16 @@ local function initializeCore()
   ]]
   function MemoryCore:addEventListener( listener )
 
-    table.insert(self.eventListeners, listener);
+    table.insert( self.eventListeners, listener );
+
+    for i, event in ipairs( listener.events ) do
+
+      -- removes the event to avoid registering them twice
+      MemoryEventFrame:UnregisterEvent( event );
+
+      -- adds the event to the memory frame
+      MemoryEventFrame:RegisterEvent( event );
+    end
   end
 
 

--- a/Memory.lua
+++ b/Memory.lua
@@ -19,8 +19,12 @@ local function initializeCore()
   -- the pattern used to wrap strings in the addon highlight color
   MemoryCore.HIGHLIGHT_PATTERN = "\124cffffee77{0}\124r";
 
+  -- the memory event listeners that will add memories
+  MemoryCore.eventListeners = {};
+
   -- the unique repository instance
   MemoryCore.repository = nil;
+
 
 
   --[[

--- a/Memory.lua
+++ b/Memory.lua
@@ -26,6 +26,18 @@ local function initializeCore()
   MemoryCore.repository = nil;
 
 
+  --[[
+  Attaches an event listener to the core.
+
+  Listeners will be triggered by player actions in the game.
+
+  @param MemoryEvent listener
+  ]]
+  function MemoryCore:addEventListener( listener )
+
+    table.insert(self.eventListeners, listener);
+  end
+
 
   --[[
   Gets the unique repository instance.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A World of Warcraft addon to register memories while players do stuff around the
 
 ### 2020.nn.nn - version 0.3.0-alpha
 * Add the `MemoryEvent` superclass
+* Add the `eventListeners` list to core
 
 ### 2020.10.18 - version 0.2.0-alpha
 * Add the MemoryRepository and its unique instance to core


### PR DESCRIPTION
[CH 537](https://app.clubhouse.io/wrike-20/story/537/criar-lista-de-eventos-em-memorycore)