### PR TITLE
Ch793/Add a debug method to MemoryEvent

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A World of Warcraft addon to register memories while players do stuff around the
 
 ### 2020.nn.nn - version 0.4.0-alpha
 * Add a debug method
+* Add a debug method to `MemoryEvent`
 
 ### 2020.10.23 - version 0.3.0-alpha
 * Add the `MemoryEvent` superclass

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A World of Warcraft addon to register memories while players do stuff around the
 ## Changelog
 
 ### 2020.nn.nn - version 0.4.0-alpha
-* Add a debug method
+* Add a debug method to `MemoryCore`
 * Add a debug method to `MemoryEvent`
 
 ### 2020.10.23 - version 0.3.0-alpha

--- a/includes/events/MemoryEvent.lua
+++ b/includes/events/MemoryEvent.lua
@@ -11,13 +11,15 @@ Constructs a new instance of a memory event.
 
 @since 0.3.0-alpha
 
+@param string name
 @param string[] events
 @param callable action
 ]]
-function MemoryEvent:new( events, action )
+function MemoryEvent:new( name, events, action )
 
   local instance = {};
   setmetatable( instance, MemoryEvent );
+  instance.name   = name;
   instance.events = events;
   instance.action = action;
 

--- a/includes/events/MemoryEvent.lua
+++ b/includes/events/MemoryEvent.lua
@@ -51,6 +51,8 @@ function MemoryEvent:new( name, events, action )
 
       if value == event then
 
+        self:debug( "Event " .. event .. " matched, calling action" );
+
         -- calls the event action
         self:action( params );
         return;

--- a/includes/events/MemoryEvent.lua
+++ b/includes/events/MemoryEvent.lua
@@ -58,5 +58,9 @@ function MemoryEvent:new( name, events, action )
     end
   end
 
+
+  -- prints a debug message after initializing the event
+  instance:debug( "Event created" );
+
   return instance;
 end

--- a/includes/events/MemoryEvent.lua
+++ b/includes/events/MemoryEvent.lua
@@ -25,6 +25,19 @@ function MemoryEvent:new( name, events, action )
 
 
   --[[
+  Prints a debug message for the specific event.
+
+  @since 0.4.0-alpha
+
+  @param string message
+  ]]
+  function instance:debug( message )
+
+    MemoryCore:debug( "[" .. self.name .. "] " .. message );
+  end
+
+
+  --[[
   Checks if the current instance triggers for the given event and call the action.
 
   @since 0.3.0-alpha


### PR DESCRIPTION
## Story

[CH 793](https://app.clubhouse.io/wrike-20/story/793/tornar-memoryevent-depur%C3%A1vel)

## Before merge

- [x] Changelog was updated
