### PR TITLE
Ch883/Reduce some resources exposure after core's initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,22 +5,24 @@ A World of Warcraft addon to register memories while players do stuff around the
 ## Changelog
 
 ### 2020.nn.nn - version 0.4.0-alpha
-* Add a debug method to `MemoryCore`
-* Add a debug method to `MemoryEvent`
-* Add the `appendEvents` method to attach all the listeners to core
-* Add the first 8 event listeners to core
+* Dev - Add a debug method to `MemoryCore`
+* Dev - Add a debug method to `MemoryEvent`
+* Dev - Add the `appendEvents` method to attach all the listeners to core
+* Dev - Add the first 8 event listeners to core
+* Dev - Make MemoryRepository a real singleton
+* Dev - Prevent MemoryEvents from being initialized after core's initialization
 
 ### 2020.10.23 - version 0.3.0-alpha
-* Add the `MemoryEvent` superclass
-* Add the `eventListeners` list to core
-* Add the event dispatcher in MemoryCore
+* Dev - Add the `MemoryEvent` superclass
+* Dev - Add the `eventListeners` list to core
+* Dev - Add the event dispatcher in MemoryCore
 
 ### 2020.10.18 - version 0.2.0-alpha
-* Add the MemoryRepository and its unique instance to core
-* Add the check and store methods to repository
-* Craft the main memory string
+* Dev - Add the MemoryRepository and its unique instance to core
+* Dev - Add the check and store methods to repository
+* Dev - Craft the main memory string
 
 ### 2020.10.15 - version 0.1.0-alpha
-* Add the `.toc` file
-* Add the `MemoryCore` object
-* Print the addon number after initialization
+* Dev - Add the `.toc` file
+* Dev - Add the `MemoryCore` object
+* Dev - Print the addon number after initialization

--- a/includes/events/MemoryEvent.lua
+++ b/includes/events/MemoryEvent.lua
@@ -69,3 +69,14 @@ function MemoryEvent:new( name, events, action )
 
   return instance;
 end
+
+
+--[[
+Destroys the MemoryEvent prototype to prevent it from being exposed after core's initialization.
+
+@since 0.4.0-alpha
+]]
+function MemoryEvent:destroyPrototype()
+
+  MemoryEvent = nil;
+end

--- a/includes/events/MemoryEvents.lua
+++ b/includes/events/MemoryEvents.lua
@@ -148,4 +148,7 @@ function MemoryAddon_appendEvents( core )
 
   -- prevents MemoryEvent from being exposed after all events are created
   MemoryEvent:destroyPrototype();
+
+  -- prevents this method to be called again
+  MemoryAddon_appendEvents = nil;
 end

--- a/includes/events/MemoryEvents.lua
+++ b/includes/events/MemoryEvents.lua
@@ -145,4 +145,7 @@ function MemoryAddon_appendEvents( core )
   ) );
 
   core:debug( "Events appended" );
+
+  -- prevents MemoryEvent from being exposed after all events are created
+  MemoryEvent:destroyPrototype();
 end

--- a/includes/repository/MemoryRepository.lua
+++ b/includes/repository/MemoryRepository.lua
@@ -155,19 +155,6 @@ function MemoryRepository:new( player, realm )
 
 
   --[[
-  Destroys the MemoryRepository prototype to prevent it from being initialized again.
-
-  This is the closest thing to a singleton I could come with so far.
-
-  @since 0.4.0-alpha
-  ]]
-  function instance:destroyPrototype()
-
-    MemoryRepository = nil;
-  end
-
-
-  --[[
   Stores a player's memory.
 
   @since 0.2.0-alpha
@@ -218,7 +205,20 @@ function MemoryRepository:new( player, realm )
   instance:checkMyself();
 
   -- destroys the prototype, so instance will be unique
-  instance:destroyPrototype();
+  MemoryRepository:destroyPrototype();
 
   return instance;
+end
+
+
+--[[
+Destroys the MemoryRepository prototype to prevent it from being initialized again.
+
+This is the closest thing to a singleton I could come with so far.
+
+@since 0.4.0-alpha
+]]
+function MemoryRepository:destroyPrototype()
+
+  MemoryRepository = nil;
 end

--- a/includes/repository/MemoryRepository.lua
+++ b/includes/repository/MemoryRepository.lua
@@ -155,6 +155,19 @@ function MemoryRepository:new( player, realm )
 
 
   --[[
+  Destroys the MemoryRepository prototype to prevent it from being initialized again.
+
+  This is the closest thing to a singleton I could come with so far.
+
+  @since 0.4.0-alpha
+  ]]
+  function instance:destroyPrototype()
+
+    MemoryRepository = nil;
+  end
+
+
+  --[[
   Stores a player's memory.
 
   @since 0.2.0-alpha
@@ -203,6 +216,9 @@ function MemoryRepository:new( player, realm )
 
   -- may initialize the player's memories
   instance:checkMyself();
+
+  -- destroys the prototype, so instance will be unique
+  instance:destroyPrototype();
 
   return instance;
 end


### PR DESCRIPTION
## Story

[CH 883](https://app.clubhouse.io/wrike-20/story/883/melhorias-nos-singletons-e-destrui%C3%A7%C3%A3o-de-fun%C3%A7%C3%B5es-globais)

## Before merge

- [x] Changelog was updated
