### PR TITLE
Ch1084/Refactor MemoryEvent to print memories before saving

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A World of Warcraft addon to register memories while players do stuff around the
 ## Changelog
 
 ### 2020.nn.nn - version 0.5.0-beta
+* Feature - Saved memories have a 10% chance to be printed to the chat frame
 * Dev - Add the `Memory` prototype
 * Dev - Add a `get` method to `MemoryRepository`
 

--- a/includes/domain/Memory.lua
+++ b/includes/domain/Memory.lua
@@ -185,7 +185,7 @@ function MemoryAddon_addMemoryPrototype( repository )
     ]]
     function instance:maybePrint()
 
-      if math.random() <= 0.1 then
+      if self:hasFirst() and math.random() <= 0.1 then
 
         self:print();
       end

--- a/includes/events/MemoryEvent.lua
+++ b/includes/events/MemoryEvent.lua
@@ -88,11 +88,17 @@ function MemoryEvent:new( name, events, action )
   ]]
   function instance:printAndSave( category, path, interactionType, --[[optional]] x )
 
+    -- sets the default value for x if not defined
+    x = x or 1;
+
     -- gets the memory from repository (may be already saved or a new kind of memory)
     local memory = MemoryCore:getRepository():get( category, path, interactionType );
 
     -- may print it
     memory:maybePrint();
+
+    -- prevents x to duplicate on save()
+    memory:setX( x );
 
     -- saves the memory
     memory:save();

--- a/includes/events/MemoryEvent.lua
+++ b/includes/events/MemoryEvent.lua
@@ -76,6 +76,21 @@ function MemoryEvent:new( name, events, action )
   end
 
 
+  --[[
+  Stores a player's memory and may print it before (or not).
+
+  @since 0.5.0-beta
+
+  @param string category
+  @param string[] path
+  @param string interactionType
+  @param int x (optional)
+  ]]
+  function instance:printAndSave( category, path, interactionType, --[[optional]] x )
+
+  end
+
+
   -- prints a debug message after initializing the event
   instance:debug( "Event created" );
 

--- a/includes/events/MemoryEvent.lua
+++ b/includes/events/MemoryEvent.lua
@@ -88,6 +88,14 @@ function MemoryEvent:new( name, events, action )
   ]]
   function instance:printAndSave( category, path, interactionType, --[[optional]] x )
 
+    -- gets the memory from repository (may be already saved or a new kind of memory)
+    local memory = MemoryCore:getRepository():get( category, path, interactionType );
+
+    -- may print it
+    memory:maybePrint();
+
+    -- saves the memory
+    memory:save();
   end
 
 

--- a/includes/events/MemoryEvents.lua
+++ b/includes/events/MemoryEvents.lua
@@ -119,7 +119,7 @@ function MemoryAddon_addEvents( core )
   ]]
   local eventNpcFight = MemoryEvent:new(
     "EventNpcFight",
-    { 'COMBAT_LOG_EVENT', 'ZONE_CHANGED' },
+    { 'COMBAT_LOG_EVENT', 'COMBAT_LOG_EVENT_UNFILTERED', 'ZONE_CHANGED' },
     function( listener, event, params )
 
       if 'ZONE_CHANGED' == event and not InCombatLockdown() then
@@ -136,9 +136,10 @@ function MemoryAddon_addEvents( core )
 
       -- gets player guid to be used on the next conditionals
       local playerGuid = UnitGUID( 'player' );
+      local playerName = UnitName( 'player' );
 
       -- exit condition if player is not the owner of the attack
-      if not playerGuid == sourceGuid then return listener:debugAndExit( "Player didn't attack" ); end
+      if playerName ~= sourceName then return listener:debugAndExit( "Player didn't attack" ); end
 
       -- exit condition if player was attacked
       if playerGuid == destGuid then return listener:debugAndExit( "Player was attacked" ); end

--- a/includes/events/MemoryEvents.lua
+++ b/includes/events/MemoryEvents.lua
@@ -51,7 +51,7 @@ function MemoryAddon_addEvents( core )
         if MemoryCore:getArrayHelper():inArray( target:getName(), listener.lastNpcs ) then return listener:debugAndExit( "Recent business" ); end
 
         -- stores the player memory about doing business with that npc
-        MemoryCore:getRepository():store( 'npcs', { target:getName() }, 'business' );
+        listener:printAndSave( 'npcs', { target:getName() }, 'business' );
 
         -- will prevent the memory to be recorded twice if player does business with the same npc again before leaving the zone
         table.insert( listener.lastNpcs, target:getName() );
@@ -101,7 +101,7 @@ function MemoryAddon_addEvents( core )
       if MemoryCore:getArrayHelper():inArray( target:getName(), listener.lastNpcs ) then return listener:debugAndExit( "Spoke recently" ); end
 
       -- stores the player memory about talking with that npc
-      MemoryCore:getRepository():store( "npcs", { target:getName() }, "talk" );
+      listener:printAndSave( "npcs", { target:getName() }, "talk" );
 
       -- will prevent the memory to be recorded twice if player talks with the same npc again before leaving the zone
       table.insert( listener.lastNpcs, target:getName() );
@@ -153,7 +153,7 @@ function MemoryAddon_addEvents( core )
       if destName == nil or '' == destName then return listener:debugAndExit( 'destName is null or empty' ); end
 
       -- stores a memory of fighting the npc
-      MemoryCore:getRepository():store( "npcs", { destName }, "fight" );
+      listener:printAndSave( "npcs", { destName }, "fight" );
 
       -- will prevent the memory to be recorded twice if player fights with the same npc again before
       table.insert( listener.lastNpcs, destGuid );
@@ -181,7 +181,7 @@ function MemoryAddon_addEvents( core )
       for i, playerGuid in pairs( uniqueMembers ) do
 
         -- adds a party memory
-        MemoryCore:getRepository():store( 'players', { playerGuid }, 'party' );
+        listener:printAndSave( 'players', { playerGuid }, 'party' );
 
         -- will prevent the memory to be recorded twice if player has grouped with that member recently
         table.insert( listener.lastPlayers, playerGuid );
@@ -223,7 +223,7 @@ function MemoryAddon_addEvents( core )
       if not zoneName == listener.lastZone then
 
         -- stores a memory about the new zone player is visiting
-        MemoryCore:getRepository():store( "zones", { zoneName }, "visit" );
+        listener:printAndSave( "zones", { zoneName }, "visit" );
 
         -- will prevent the memory to be recorded twice in another event call
         listener.lastZone = zoneName;
@@ -243,7 +243,7 @@ function MemoryAddon_addEvents( core )
       if MemoryCore:getArrayHelper():inArray( subZoneName, listener.lastSubZones ) then return listener:debugAndExit( "Player hasn't changed subzones" ); end
 
       -- stores a memory about the new sub zone player is visiting
-      MemoryCore:getRepository():store( "zones", { zoneName, "subzones", subZoneName }, "visit" );
+      listener:printAndSave( "zones", { zoneName, "subzones", subZoneName }, "visit" );
 
       -- will prevent the memory to be recorded twice in another event call
       table.insert( listener.lastSubZones, subZoneName );
@@ -278,7 +278,7 @@ function MemoryAddon_addEvents( core )
       if not itemLootInfo.valid then return listener:debugAndExit( "Invalid item" ); end
 
       -- stores a memory about looting the item
-      MemoryCore:getRepository():store( 'items', { itemLootInfo.name }, 'loot', itemLootInfo.quantity );
+      listener:printAndSave( 'items', { itemLootInfo.name }, 'loot', itemLootInfo.quantity );
     end
   );
   core:addEventListener( eventItemLoot );

--- a/includes/repository/MemoryRepository.lua
+++ b/includes/repository/MemoryRepository.lua
@@ -241,7 +241,7 @@ function MemoryRepository:new( player, realm )
     -- sanity check
     if memory == nil or not memory:isValid() then
 
-      MemoryCore:debug( 'Attempt to save an invalid memory' );
+      MemoryCore:debug( 'Attempt to save an invalid memory', true );
 
       return;
     end


### PR DESCRIPTION
## Story

[CH 1084](https://app.clubhouse.io/wrike-20/story/1084/memoryevent-ajustes-para-utiliza%C3%A7%C3%A3o-de-memory)

## Before merge

- [x] Changelog was updated
